### PR TITLE
Update wpilib dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ctre-sys = { path = "ctre-sys", version = "5.5.0" }
 
 [dependencies.wpilib-sys]
 optional = true
-version = "0.3.0"
+version = "0.4.0"
 
 [workspace]
 members = [".", "ctre-sys"]


### PR DESCRIPTION
This will allow ctre-rs to build on stable.